### PR TITLE
Fix date format spacing and stray header character

### DIFF
--- a/components/date-formatter.tsx
+++ b/components/date-formatter.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 const DateFormatter = ({ dateString }: Props) => {
   const date = parseISO(dateString)
-  return <time dateTime={dateString}>{format(date, 'LLLL	d, yyyy')}</time>
+  return <time dateTime={dateString}>{format(date, 'LLLL d, yyyy')}</time>
 }
 
 export default DateFormatter

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -6,7 +6,6 @@ const Header = () => {
       <Link href="/" className="hover:underline">
         Back to Jeff's Blog
       </Link>
-      .
     </h2>
   )
 }


### PR DESCRIPTION
## Summary
- clean up the date format string to remove tab spacing
- remove stray period in the header link

## Testing
- `npm run typecheck` *(fails: Cannot find module errors)*